### PR TITLE
Failed get for github.com/gobuffalo/pop

### DIFF
--- a/templates/en/docs/db/getting-started.md
+++ b/templates/en/docs/db/getting-started.md
@@ -27,7 +27,8 @@ Pop supports the following databases:
 ## Installation
 
 ```bash
-$ go get github.com/gobuffalo/pop/...
+$ go get github.com/gobuffalo/buffalo-pop
+$ go get github.com/gobuffalo/pop
 ```
 
 ## Next Steps


### PR DESCRIPTION
I have tried variations of trying to install pop after installing buffalo.  I finally had a eureka that I need to install buffalo-pop before installing pop.  Pls check if this should be the means of installing pop so that the command "buffalo pop" works.