### PR TITLE
Failed get for github.com/gobuffalo/pop

### DIFF
--- a/templates/en/docs/db/buffalo-integration.md
+++ b/templates/en/docs/db/buffalo-integration.md
@@ -29,6 +29,10 @@ Buffalo provides a Pop middleware to ease database usage within Buffalo: https:/
 
 This middleware is configured for you by default, if you choose to use Pop when creating a new project.
 
+```bash
+$ go get github.com/gobuffalo/buffalo-pop
+```
+
 **actions/app.go**
 
 ```go


### PR DESCRIPTION
I have tried variations of trying to install pop after installing buffalo. I finally had a eureka that I need to install buffalo-pop before installing pop. Pls check if this should be the means of installing pop so that the command "buffalo pop" works.