### PR TITLE
Fix Horizontal Scroll On Desktop

### DIFF
--- a/assets/css/_general.scss
+++ b/assets/css/_general.scss
@@ -95,10 +95,6 @@ h2 {
 
     &.left-oriented {
         padding-top: 30px;
-
-        .container {
-            margin-left: 90px;
-        }
     }
 }
 

--- a/assets/css/application.scss
+++ b/assets/css/application.scss
@@ -15,6 +15,7 @@
     @media (min-width: 1400px){
         .main-content {
             max-width: 1400px;
+            width: 100%;
         }
     }
 


### PR DESCRIPTION
Hey!

First PR in the Buffalo ecosystem. It's a minor CSS fix 😬 Hoping to make more in the future.

Picked it up for one of my side-projects, and as someone who started out with RoR, Buffalo brings the welcome nostalgia. Even dumped my own custom scaffold for Buffalo, so thanks a lot for the project.

Anyway,

I noticed this annoying horizontal scroll on Desktop, due to the footer.

![Screenshot 2020-03-29 at 12 11 38 AM](https://user-images.githubusercontent.com/8947356/77831135-3e51e480-7153-11ea-94fe-0e9e1ce032ac.png)

![Screenshot 2020-03-29 at 12 12 21 AM](https://user-images.githubusercontent.com/8947356/77831158-6b05fc00-7153-11ea-934b-89e5e95693c4.png)

Although there was no scroll on mobile, but it looked misaligned

![Screenshot 2020-03-29 at 12 11 15 AM](https://user-images.githubusercontent.com/8947356/77831153-64778480-7153-11ea-9f49-deee2b62c20f.png)


The issue was a `margin-left` on the footer container. So removed that.
