### PR TITLE
Update (buffalo new) _help.md

### DIFF
--- a/templates/en/docs/new-project/_help.md
+++ b/templates/en/docs/new-project/_help.md
@@ -7,18 +7,18 @@ Usage:
 
 Flags:
       --api                  skip all front-end code and configure for an API server
-      --bootstrap int        specify version for Bootstrap [3, 4] (default 4)
-      --ci-provider string   specify the type of ci file you would like buffalo to generate [none, travis, gitlab-ci] (default "none")
+      --ci-provider string   specify the type of ci file you would like buffalo to generate [none, travis, gitlab-ci, circleci] (default "none")
       --config string        config file (default is $HOME/.buffalo.yaml)
-      --db-type string       specify the type of database you want to use [cockroach, mysql, postgres, sqlite3] (default "postgres")
+      --db-type string       specify the type of database you want to use [cockroach, mariadb, mysql, postgres] (default "postgres")
       --docker string        specify the type of Docker file to generate [none, multi, standard] (default "multi")
+  -d, --dry-run              dry run
   -f, --force                delete and remake if the app already exists
   -h, --help                 help for new
+      --module string        specify the root module (package) name. [defaults to 'automatic']
       --skip-config          skips using the config file
       --skip-pop             skips adding pop/soda to your app
       --skip-webpack         skips adding Webpack to your app
       --skip-yarn            use npm instead of yarn for frontend dependencies management
       --vcs string           specify the Version control system you would like to use [none, git, bzr] (default "git")
   -v, --verbose              verbosely print out the go get commands
-      --with-dep             adds github.com/golang/dep to your app
 ```


### PR DESCRIPTION
the current version of buffalo shows different options

Generated with version v0.16.9
```bash
$ buffalo version
INFO[0000] Buffalo version is: v0.16.9                  


$ buffalo help new
Creates a new Buffalo application

Usage:
  buffalo new [name] [flags]

Flags:
      --api                  skip all front-end code and configure for an API server
      --ci-provider string   specify the type of ci file you would like buffalo to generate [none, travis, gitlab-ci, circleci] (default "none")
      --config string        config file (default is $HOME/.buffalo.yaml)
      --db-type string       specify the type of database you want to use [cockroach, mariadb, mysql, postgres] (default "postgres")
      --docker string        specify the type of Docker file to generate [none, multi, standard] (default "multi")
  -d, --dry-run              dry run
  -f, --force                delete and remake if the app already exists
  -h, --help                 help for new
      --module string        specify the root module (package) name. [defaults to 'automatic']
      --skip-config          skips using the config file
      --skip-pop             skips adding pop/soda to your app
      --skip-webpack         skips adding Webpack to your app
      --skip-yarn            use npm instead of yarn for frontend dependencies management
      --vcs string           specify the Version control system you would like to use [none, git, bzr] (default "git")
  -v, --verbose              verbosely print out the go get commands
```