### PR TITLE
Call Skip on middleware stack instead of on app

### DIFF
--- a/templates/en/docs/middleware/_skipping.md
+++ b/templates/en/docs/middleware/_skipping.md
@@ -39,18 +39,18 @@ m2 := MyMiddleware()
 
 app.Use(m1)
 
-app.Skip(m2, Foo, Bar) // WON'T WORK m2 != m1
-app.Skip(m1, Foo, Bar) // WORKS
+app.Middleware.Skip(m2, Foo, Bar) // WON'T WORK m2 != m1
+app.Middleware.Skip(m1, Foo, Bar) // WORKS
 ```
 
 ```go
 // EXAMPLE 2
 app.Resource("/widgets", WidgetResource{})
-app.Skip(mw, WidgetResource{}.Show) // WON'T WORK
+app.Middleware.Skip(mw, WidgetResource{}.Show) // WON'T WORK
 
 wr := WidgetResource{}
 app.Resource("/widgets", wr)
-app.Skip(mw, wr.Show) // WORKS
+app.Middleware.Skip(mw, wr.Show) // WORKS
 ```
 
 <% } %>


### PR DESCRIPTION
The example about Skipping middleware in the important notice box seems to bee calling Skip() directly on the app instance instead of the MiddlewareStack.

According to [Godoc](https://godoc.org/github.com/gobuffalo/buffalo#MiddlewareStack.Skip) only the MiddlewareStack has a Skip() method.