### PR TITLE
Adds example of including columns in model generation

### DIFF
--- a/templates/en/docs/db/models.md
+++ b/templates/en/docs/db/models.md
@@ -40,6 +40,18 @@ Writing the files by hand is not the most efficient way to work. Soda (and Buffa
 
 <%= partial("en/docs/db/model.md") %>
 
+You can specify each column of the model to soda in order for it to generate the code for you, like this:
+
+```bash
+$ soda generate model [name] [column1]:[type] [column2]:[type]
+```
+
+This is how you would generate a person-model with columns for the persons name, age and bio:
+
+```bash
+$ soda generate model person name:string age:int bio:text
+```
+
 You can remove generated model by running:
 
 ```bash


### PR DESCRIPTION
I noticed in [The Unofficial pop Book](https://andrew-sledge.gitbooks.io/the-unofficial-pop-book/content/installation.html#3-create-a-model) that the pop/soda generate command has the capability to accept column names and data types.

I believe this is something very convenient and useful for the community that should be included on the Models page under [Using the generator](https://gobuffalo.io/en/docs/db/models/#using-the-generator).
