### PR TITLE
Remove typo, simplify wording

### DIFF
--- a/templates/en/docs/db/fizz.md
+++ b/templates/en/docs/db/fizz.md
@@ -3,7 +3,7 @@
 
 <%= h1("Fizz") %>
 
-Fizz is a common DSL for migrating databases. It tries to be as database-agnostic as possible. This is the language used by defaut by Pop to define [database migrations](/en/docs/db/migrations).
+Fizz is a common DSL for migrating databases. It tries to be as database-agnostic as possible. This is the default language used by Pop to define [database migrations](/en/docs/db/migrations).
 
 ## Create a Table
 


### PR DESCRIPTION
I came across a typo of "default" on a docs page.

Rather than just fix the typo I also rephrased the sentence a little to be simpler (I hope!)