### PR TITLE
Fix link to release page of gobuffalo

### DIFF
--- a/templates/home.fr.html
+++ b/templates/home.fr.html
@@ -10,7 +10,7 @@
         </p>
         <div class="last-info">
           <p>Dernière version :</p>
-          <a class="badge badge-pill" href="https://github.com/gobuffalo/buffalo/releases/latest" target="_blank" rel="noopener noreferrer"><%= version %></a>
+          <a class="badge badge-pill" href="https://github.com/gobuffalo/cli/releases/latest" target="_blank" rel="noopener noreferrer"><%= version %></a>
         </div>
         <div class="last-info">
           <p>Nécessite :</p>

--- a/templates/home.html
+++ b/templates/home.html
@@ -10,7 +10,7 @@
         </p>
         <div class="last-info">
         <p>Latest release:</p>
-          <a class="badge badge-pill" href="https://github.com/gobuffalo/buffalo/releases/latest" target="_blank" rel="noopener noreferrer"><%= version %></a>
+          <a class="badge badge-pill" href="https://github.com/gobuffalo/cli/releases/latest" target="_blank" rel="noopener noreferrer"><%= version %></a>
         </div>
         <div class="last-info">
           <p>Requires:</p>


### PR DESCRIPTION
The link in the badge on the website uses the version information from the cli repository but still links to the gobuffalo/buffalo repository. This PR fixes the link.