### PR TITLE
fixed custom installation commands (version string)

### DIFF
--- a/templates/en/docs/getting-started/installation.md
+++ b/templates/en/docs/getting-started/installation.md
@@ -102,7 +102,7 @@ $ gofish install buffalo
 To install Buffalo, ensure your `GOPATH` is defined, then:
 
 ```bash
-$ go get -u -v -tags sqlite github.com/gobuffalo/cli/cmd/buffalo@<%= version %>
+$ go get -u -v -tags sqlite github.com/gobuffalo/cli/cmd/buffalo@v<%= version %>
 ```
 
 **Windows Users**: Follow the installation guide at [https://blog.gobuffalo.io/install-buffalo-on-windows-10-e08b3aa304a3](https://blog.gobuffalo.io/install-buffalo-on-windows-10-e08b3aa304a3) to install a GCC for Windows 10. Alternatively, GCC can be installed with the [Scoop](http://scoop.sh/) package manager:
@@ -118,7 +118,7 @@ These instructions can also be used for upgrading to a newer version of Buffalo.
 ## Custom installation **without** SQLite3 Support
 
 ```bash
-$ go install github.com/gobuffalo/cli/cmd/buffalo@<%= version %>
+$ go install github.com/gobuffalo/cli/cmd/buffalo@v<%= version %>
 ```
 
 <%= note() { %>

--- a/templates/fr/docs/getting-started/installation.md
+++ b/templates/fr/docs/getting-started/installation.md
@@ -102,7 +102,7 @@ $ gofish install buffalo
 Pour installer Buffalo, assurez-vous que le `GOPATH` est défini, puis&nbsp;:
 
 ```bash
-$ go get -u -v -tags sqlite github.com/gobuffalo/cli/cmd/buffalo@<%= version %>
+$ go get -u -v -tags sqlite github.com/gobuffalo/cli/cmd/buffalo@v<%= version %>
 ```
 
 **Utilisateurs de Windows**&nbsp;: Suivez le guide d'installation [https://blog.gobuffalo.io/install-buffalo-on-windows-10-e08b3aa304a3 (EN)](https://blog.gobuffalo.io/install-buffalo-on-windows-10-e08b3aa304a3) pour installer GCC sur Windows 10. GCC peut également être installé via le gestionnaire de paquets [Scoop](http://scoop.sh/) :
@@ -118,7 +118,7 @@ Ces instructions peuvent aussi être utilisées pour mettre à jour votre versio
 ## Installation personnalisée **sans** support pour SQLite3
 
 ```bash
-$ go install github.com/gobuffalo/cli/cmd/buffalo@<%= version %>
+$ go install github.com/gobuffalo/cli/cmd/buffalo@v<%= version %>
 ```
 
 <%= note() { %>

--- a/templates/it/docs/getting-started/installation.md
+++ b/templates/it/docs/getting-started/installation.md
@@ -102,7 +102,7 @@ $ gofish install buffalo
 Per installare Buffalo, assicurati di aver definito `GOPATH`, quindi:
 
 ```bash
-$ go get -u -v -tags sqlite github.com/gobuffalo/cli/cmd/buffalo@<%= version %>
+$ go get -u -v -tags sqlite github.com/gobuffalo/cli/cmd/buffalo@v<%= version %>
 ```
 
 **Utenti Windows**: Segui la guida d'installazione su [https://blog.gobuffalo.io/install-buffalo-on-windows-10-e08b3aa304a3](https://blog.gobuffalo.io/install-buffalo-on-windows-10-e08b3aa304a3) per installare un GCC su Windows 10. In alternativa, GCC può essere installato con il gestore di pacchetti [Scoop](http://scoop.sh/):
@@ -118,7 +118,7 @@ Queste istruzioni possono essere usate anche per aggiornare Buffalo a una nuova 
 ## Installazione personalizzata **senza** supporto a SQLite3
 
 ```bash
-$ go install github.com/gobuffalo/cli/cmd/buffalo@<%= version %>
+$ go install github.com/gobuffalo/cli/cmd/buffalo@v<%= version %>
 ```
 
 <%= note() { %>


### PR DESCRIPTION
I found that 'v' is missing in the version string of the command line for custom build steps. added them for three languages.