### PR TITLE
Add documentation for routing Host introduced in 0.18.2

### DIFF
--- a/templates/en/docs/routing.md
+++ b/templates/en/docs/routing.md
@@ -15,4 +15,5 @@ Buffalo uses the [github.com/gorilla/mux](http://www.gorillatoolkit.org/pkg/mux)
 <%= partial("en/docs/routing/params.md") %>
 <%= partial("en/docs/routing/named_params.md") %>
 <%= partial("en/docs/routing/groups.md") %>
+<%= partial("en/docs/routing/hosts.md") %>
 <%= partial("en/docs/routing/mounting.md") %>

--- a/templates/en/docs/routing/_hosts.md
+++ b/templates/en/docs/routing/_hosts.md
@@ -1,0 +1,33 @@
+## Hosts
+
+<%= sinceVersion("0.18.2") %>
+
+Buffalo apps also support grouping of end-points by host. Host creates a new group that matches the domain passed. This is useful for creating groups of end-points for different domains or subdomains.
+
+```go
+app := buffalo.New(buffalo.Options{
+    Env:         envy.Get("GO_ENV", "development"),
+    SessionName: "_coke_session",
+})
+
+app.GET("/", func (c buffalo.Context) error {
+  return c.Render(http.StatusOK, r.String("Main App Homepage"))
+})
+
+subApp := app.Host("docs.domain.com")
+subApp.GET("/", func (c buffalo.Context) error {
+  return c.Render(http.StatusOK, r.String("docs.domain.com Homepage"))
+})
+
+domainApp := app.Host("example.com")
+domainApp.GET("/", func (c buffalo.Context) error {
+  return c.Render(http.StatusOK, r.String("example.com Homepage"))
+})
+```
+
+Variables mapped to parameters are also supported:
+
+```go
+app.Host("{subdomain}.example.com")
+app.Host("{subdomain:[a-z]+}.example.com")
+```

--- a/templates/en/docs/routing/_hosts.md
+++ b/templates/en/docs/routing/_hosts.md
@@ -10,10 +10,6 @@ app := buffalo.New(buffalo.Options{
     SessionName: "_coke_session",
 })
 
-app.GET("/", func (c buffalo.Context) error {
-  return c.Render(http.StatusOK, r.String("Main App Homepage"))
-})
-
 subApp := app.Host("docs.domain.com")
 subApp.GET("/", func (c buffalo.Context) error {
   return c.Render(http.StatusOK, r.String("docs.domain.com Homepage"))
@@ -22,6 +18,10 @@ subApp.GET("/", func (c buffalo.Context) error {
 domainApp := app.Host("example.com")
 domainApp.GET("/", func (c buffalo.Context) error {
   return c.Render(http.StatusOK, r.String("example.com Homepage"))
+})
+
+app.GET("/", func (c buffalo.Context) error {
+  return c.Render(http.StatusOK, r.String("Main App Homepage"))
 })
 ```
 

--- a/templates/en/docs/routing/_hosts.md
+++ b/templates/en/docs/routing/_hosts.md
@@ -2,7 +2,7 @@
 
 <%= sinceVersion("0.18.2") %>
 
-Buffalo apps also support grouping of end-points by host. Host creates a new group that matches the domain passed. This is useful for creating groups of end-points for different domains or subdomains.
+Buffalo apps also support grouping of end-points by host. `Host` creates a new group that matches the domain passed. This is useful for creating groups of end-points for different domains or subdomains.
 
 ```go
 app := buffalo.New(buffalo.Options{

--- a/templates/fr/docs/routing.md
+++ b/templates/fr/docs/routing.md
@@ -15,4 +15,5 @@ Buffalo utilise le paquet [github.com/gorilla/mux](http://www.gorillatoolkit.org
 <%= partial("fr/docs/routing/params.md") %>
 <%= partial("fr/docs/routing/named_params.md") %>
 <%= partial("fr/docs/routing/groups.md") %>
+<%= partial("fr/docs/routing/hosts.md") %>
 <%= partial("fr/docs/routing/mounting.md") %>

--- a/templates/fr/docs/routing/_hosts.md
+++ b/templates/fr/docs/routing/_hosts.md
@@ -10,10 +10,6 @@ app := buffalo.New(buffalo.Options{
     SessionName: "_coke_session",
 })
 
-app.GET("/", func (c buffalo.Context) error {
-  return c.Render(http.StatusOK, r.String("Main App Homepage"))
-})
-
 subApp := app.Host("docs.domain.com")
 subApp.GET("/", func (c buffalo.Context) error {
   return c.Render(http.StatusOK, r.String("docs.domain.com Homepage"))
@@ -22,6 +18,10 @@ subApp.GET("/", func (c buffalo.Context) error {
 domainApp := app.Host("example.com")
 domainApp.GET("/", func (c buffalo.Context) error {
   return c.Render(http.StatusOK, r.String("example.com Homepage"))
+})
+
+app.GET("/", func (c buffalo.Context) error {
+  return c.Render(http.StatusOK, r.String("Main App Homepage"))
 })
 ```
 

--- a/templates/fr/docs/routing/_hosts.md
+++ b/templates/fr/docs/routing/_hosts.md
@@ -2,7 +2,7 @@
 
 <%= sinceVersion("0.18.2") %>
 
-Buffalo prennent également en charge le regroupement des points de terminaison par hôte. L'hôte crée un nouveau groupe qui correspond au domaine transmis. Ceci est utile pour créer des groupes de points de terminaison pour différents domaines ou sous-domaines.
+Buffalo supporte également le regroupement d'APIs par domaine. La méthode `Host` crée un nouveau groupe pour le nom de domaine passé en paramètre, ce qui peut être une méthode pratique pour regrouper des APIs appartenant au même domaine (voire gérer plusieurs sous-domaines sur une même application).
 
 ```go
 app := buffalo.New(buffalo.Options{
@@ -25,7 +25,7 @@ app.GET("/", func (c buffalo.Context) error {
 })
 ```
 
-Les variables mappées aux paramètres sont également prises en charge:
+Les variables associéees aux paramètres sont également prises en charge :
 
 ```go
 app.Host("{subdomain}.example.com")

--- a/templates/fr/docs/routing/_hosts.md
+++ b/templates/fr/docs/routing/_hosts.md
@@ -1,0 +1,33 @@
+## Hôtes
+
+<%= sinceVersion("0.18.2") %>
+
+Buffalo prennent également en charge le regroupement des points de terminaison par hôte. L'hôte crée un nouveau groupe qui correspond au domaine transmis. Ceci est utile pour créer des groupes de points de terminaison pour différents domaines ou sous-domaines.
+
+```go
+app := buffalo.New(buffalo.Options{
+    Env:         envy.Get("GO_ENV", "development"),
+    SessionName: "_coke_session",
+})
+
+app.GET("/", func (c buffalo.Context) error {
+  return c.Render(http.StatusOK, r.String("Main App Homepage"))
+})
+
+subApp := app.Host("docs.domain.com")
+subApp.GET("/", func (c buffalo.Context) error {
+  return c.Render(http.StatusOK, r.String("docs.domain.com Homepage"))
+})
+
+domainApp := app.Host("example.com")
+domainApp.GET("/", func (c buffalo.Context) error {
+  return c.Render(http.StatusOK, r.String("example.com Homepage"))
+})
+```
+
+Les variables mappées aux paramètres sont également prises en charge:
+
+```go
+app.Host("{subdomain}.example.com")
+app.Host("{subdomain:[a-z]+}.example.com")
+```


### PR DESCRIPTION
The `Host` function was introduced in [v0.18.2](https://github.com/gobuffalo/buffalo/releases/tag/v0.18.2) from [this PR](https://github.com/gobuffalo/buffalo/pull/2185).

I've added documentation for English and attempted a translation to French via Google Translate.