### PR TITLE
Adjustments docs and fix erb highlighted code blocks

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -65,7 +65,7 @@ html {
     @apply p-3 overflow-scroll;
 }
 
-.content p code {
+.content p code, li code {
     @apply bg-gray-200 p-1 rounded-md text-base;
 }
 

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -12,17 +12,24 @@ document.addEventListener('DOMContentLoaded', () =>{
 function setupMobileSidebar() {
     document.querySelector('#mobile-open-menu-button').addEventListener("click", (e) => {
         document.querySelector("#mobile-docs-sidebar").classList.remove("hidden");
-    });    
+    });
 
     document.querySelector('#mobile-docs-sidebar .close').addEventListener("click", (e) => {
         document.querySelector("#mobile-docs-sidebar").classList.add("hidden");
-    });   
+    });
 }
 
 function colorizeCode() {
     document.querySelectorAll('code[data-lang="erb"]').forEach((el) => {
-        el.parentNode.classList.add("language-erb");
-        hljs.highlightElement(el.parentNode);
+        let codeBlock = el.parentNode;
+        codeBlock.classList.add("language-erb");
+
+        let hl = document.createElement('div');
+        hl.classList.add('highlight')
+        codeBlock.parentNode.insertBefore(hl, codeBlock);
+        hl.append(codeBlock);
+
+        hljs.highlightElement(codeBlock);
     });
 }
 

--- a/content/documentation/database/configuration.md
+++ b/content/documentation/database/configuration.md
@@ -142,7 +142,7 @@ The database host port for the database.
 **Defaults**:
 
 | Driver    | Port  |
-|-----------|-------|
+|:-----------|:-------|
 | PostgreSQL| 5432  |
 | MySQL     | 3306  |
 | Cockroach | 26257 |

--- a/content/documentation/database/models.md
+++ b/content/documentation/database/models.md
@@ -147,7 +147,7 @@ This is very similar to how [form binding](/docs/bind) works.
 Any types can be used that adhere to the [Scanner](https://golang.org/pkg/database/sql/#Scanner) and [Valuer](https://golang.org/pkg/database/sql/driver/#Valuer) interfaces, however, so that you don't have to write these yourself it is recommended you stick with the following types:
 
 | Base type             | Nullable        | Slice/Array |
-|-----------------------|:---------------:|------------:|
+|:-----------------------|:---------------|:------------|
 |int                    |nulls.Int        |slices.Int   |
 |int32                  |nulls.Int32      | ------      |
 |int64                  |nulls.Int64      | ------      |
@@ -163,7 +163,7 @@ Any types can be used that adhere to the [Scanner](https://golang.org/pkg/databa
 
 {{< note >}}
 **Note**: Any `slices.Map` typed fields will need to be initialized before `Bind`ing or accessing.
-```go 
+```go
 widget := &models.Widget{Data: slices.Map{}}
 ```
 {{< /note >}}
@@ -263,7 +263,7 @@ func (u User) TableName() string {
 
 It is recommended to use a value receiver over a pointer receiver if the struct is used as a value anywhere in the code.
 
-```
+```go
 // recommended:
 func (u User) TableName() string {
 

--- a/content/documentation/database/onetomany.md
+++ b/content/documentation/database/onetomany.md
@@ -72,7 +72,7 @@ type Tree struct {
 }
 ```
 
-The format to use is `order_by:"&lt;column_name> &lt;asc | desc>"`.
+The format to use is `order_by:"<column_name> <asc | desc>"`.
 
 ## Customize foreign keys lookup
 

--- a/content/documentation/database/relations.md
+++ b/content/documentation/database/relations.md
@@ -60,7 +60,7 @@ Using the above [example](#example) code below is a list of available struct tag
 
 * `fk_id`: This tag can be used to define the column name in the target association that matches model ID. In the example above, `Song` has a column named `u_id` that references the id of the `users` table. When loading `FavoriteSong`, `u_id` column will be used instead of `user_id`.
 
-* `order_by`: This tag can be used in combination with `has_many` and `many_to_many` tags to indicate the order for the association when loading. The format to use is `order_by:"&lt;column_name> &lt;asc | desc>"`
+* `order_by`: This tag can be used in combination with `has_many` and `many_to_many` tags to indicate the order for the association when loading. The format to use is `order_by:"<column_name> <asc | desc>"`
 
 ## Loading Associations
 Pop currently provides two modes for loading associations; each mode will affect the way pop loads associations and queries to the database.
@@ -99,20 +99,21 @@ err := tx.Eager().All(&u)  // loads all associations for every user registered, 
 ```
 
 `Eager` mode will:
- 1. Load all users.  
-```
+ 1. Load all users.
+```text
  SELECT * FROM users;
 ```
-2. Iterate on every user and load its associations:  
-```
+2. Iterate on every user and load its associations:
+
+```erb
  SELECT * FROM books WHERE user_id=1)
-```  
 ```
- SELECT * FROM books WHERE user_id=2)  
-```  
+```erb
+ SELECT * FROM books WHERE user_id=2)
 ```
+```erb
  SELECT * FROM books WHERE user_id=3)
-``` 
+```
 
 ## EagerPreload Mode
 The [`pop.Connection.EagerPreload()`](https://github.com/gobuffalo/pop/pull/146/files#diff-f49e947ec94f65964b0845af2b62845aR180) method tells Pop to load the associations for a model once that model is loaded from the database. This mode will hit the database with a reduced frequency by sacrifing more memory space.
@@ -136,11 +137,11 @@ err := tx.EagerPreload().All(&u)  // loads all associations for every user regis
 
 `EagerPreload` mode will:
  1. Load all users.  
- ```
+ ```erb
   SELECT * FROM users;
  ```
 2. Load associations for all users in one single query.  
-```
+```erb
   SELECT * FROM books WHERE user_id IN (1,2,3))
 ``` 
 

--- a/content/documentation/deploy/cross-compiling.md
+++ b/content/documentation/deploy/cross-compiling.md
@@ -20,18 +20,18 @@ You can find the list of supported targets here: https://golang.org/doc/install/
 
 ### Build for AMD64 Linux
 
-```go
+```bash
 $ GOOS=linux GOARCH=amd64 buffalo build
 ```
 
 ### Build for ARM64 Linux
 
-```go
+```bash
 $ GOOS=linux GOARCH=arm64 buffalo build
 ```
 
 ### Build for i386 Windows
 
-```go
+```bash
 $ GOOS=windows GOARCH=386 buffalo build
 ```

--- a/content/documentation/deploy/proxy.md
+++ b/content/documentation/deploy/proxy.md
@@ -161,7 +161,7 @@ PORT=3000
 
 **Apache 2 config:**
 ```apache
-&lt;VirtualHost *:80&gt;
+<VirtualHost *:80>
     ProxyPreserveHost On
 
     # Proxy requests to Buffalo
@@ -169,5 +169,5 @@ PORT=3000
     ProxyPassReverse / http://0.0.0.0:3000/
 
     ServerName example.com
-&lt;/VirtualHost&gt;
+</VirtualHost>
 ```

--- a/content/documentation/frontend-layer/rendering.md
+++ b/content/documentation/frontend-layer/rendering.md
@@ -55,9 +55,9 @@ Files passed into the `render.HTML` or `render.Template` functions, that have an
 // beatles.md
 # The Beatles
 
-\<%= for (name) in names { %>
-* \<%= name %>
-\<% } %>
+<%= for (name) in names { %>
+* <%= name %>
+<% } %>
 ```
 
 ```go
@@ -99,7 +99,7 @@ The [`render.Options`](https://godoc.org/github.com/gobuffalo/buffalo/render#Opt
 The new JavaScript renderer also has it’s own implementation of the `partial` function. This new implementation behaves almost the same as the original implementation, but is smart enough to know that if you are rendering an `*.html` file inside of a `*.js` file that it will need to be escaped properly, and so it does it for you.
 
 ```javascript
-$("#new-goal-form").replaceWith("&lt;%= partial("goals/new.html") %&gt;");
+$("#new-goal-form").replaceWith("<%= partial("goals/new.html") %>");
 ```
 
 

--- a/content/documentation/guides/apis.md
+++ b/content/documentation/guides/apis.md
@@ -19,7 +19,7 @@ $ buffalo new --api coke
 Applications generated with the `--api` flag don't contain any front systems. This means there is no templating, stylesheets, etc...
 
 #### <code>buffalo new coke --api</code>
-```
+```erb
 ├── Dockerfile
 ├── README.md
 ├── actions
@@ -42,7 +42,7 @@ Applications generated with the `--api` flag don't contain any front systems. Th
 ```
 
 #### <code>buffalo new coke</code>
-```
+```erb
 ├── Dockerfile
 ├── README.md
 ├── actions

--- a/content/documentation/guides/auth.md
+++ b/content/documentation/guides/auth.md
@@ -646,7 +646,7 @@ create_table("users") {
 
 {{< codetabs >}}
 {{< tab "templates/auth/new.html" >}}
-```erb
+```html
 // templates/auth/new.html
 <style>
   .auth-wrapper{
@@ -662,7 +662,9 @@ create_table("users") {
     padding: 0 20px;
   }
 
-  .auth-wrapper h1{margin-bottom: 20px;}
+  .auth-wrapper h1{
+    margin-bottom: 20px;
+  }
 </style>
 
 <div class="auth-wrapper">
@@ -680,7 +682,7 @@ create_table("users") {
 {{< /tab>}}
 
 {{< tab "templates/new/new.html">}}
-```erb
+```html
 // templates/new/new.html
 <style>
   .auth-wrapper{
@@ -696,7 +698,9 @@ create_table("users") {
     padding: 0 20px;
   }
 
-  .auth-wrapper h1{margin-bottom: 20px;}
+  .auth-wrapper h1{
+    margin-bottom: 20px;
+  }
 </style>
 
 <div class="auth-wrapper">
@@ -716,7 +720,7 @@ create_table("users") {
 
 {{< /tab>}}
 {{< tab "templates/index.html">}}
-```erb
+```html
 // templates/index.html
 <style>
   .auth-center{

--- a/content/documentation/guides/file-uploads.md
+++ b/content/documentation/guides/file-uploads.md
@@ -11,13 +11,13 @@ Buffalo allows for the easily handling of files uploaded from a form. Storing th
 
 The `f.FileTag` form helper can be used to quickly add a file element to the form. When using this the `enctype` of the form is *automatically* switched to be `multipart/form-data`.
 
-```erb
-&lt;%= form_for(widget, {action: widgetsPath(), method: "POST"}) { %&gt;
-  &lt;%= f.InputTag("Name") %&gt;
-  &lt;%= f.FileTag("MyFile") %&gt;
-  &lt;button class="btn btn-success" role="submit"&gt;Save&lt;/button&gt;
-  &lt;a href="&lt;%= widgetsPath() %&gt;" class="btn btn-warning" data-confirm="Are you sure?"&gt;Cancel&lt;/a&gt;
-&lt;% } %&gt;
+```html
+<%= form_for(widget, {action: widgetsPath(), method: "POST"}) { %>
+  <%= f.InputTag("Name") %>
+  <%= f.FileTag("MyFile") %>
+  <button class="btn btn-success" role="submit">Save</button>
+  <a href="<%= widgetsPath() %>" class="btn btn-warning" data-confirm="Are you sure?">Cancel</a>
+<% } %>
 ```
 
 ## Accessing a Form File

--- a/content/documentation/guides/mail.md
+++ b/content/documentation/guides/mail.md
@@ -141,7 +141,7 @@ func SendMail(c buffalo.Context) error {
 ```
 
 ```html
-&lt;a href="\<%= awesomePath() %>">Click here&lt;/a>
+<a href="\<%= awesomePath() %>">Click here</a>
 ```
 
 

--- a/content/documentation/guides/workers.md
+++ b/content/documentation/guides/workers.md
@@ -37,7 +37,7 @@ Currently there are two official implementations of this interface:
 The following Worker implementations are provided by Buffalo users (no official support):
 
 | Name | Author | Description |
-|------|--------|-------------|
+|:------|:--------|:-------------|
 | [AMQP worker adapter](https://github.com/stanislas-m/amqp-work-adapter) | [@stanislas-m](https://github.com/stanislas-m) | A Worker implementation to use with AMQP-compatible brokers (such as [RabbitMQ](https://www.rabbitmq.com/)). |
 
 ## The Job type


### PR DESCRIPTION
This PR has adjustments for the following docs:

**Database**
* Configuration
    * Adjust table
* Models
    * Adjust table
    * Set go as highlight  on code block
* One to many associations
    * Replace `&lt;` character by `<`
* Relations
    * Fix plush block codes

**Guides**
* API
    * Set erb as highlight  on code blocks
* Auth
    * Fix html code blocks
* File Upload
    * Fix html code block
* Workers
    * Fixt table

**Deploy**
* Cross-compiling
    * Set bash as highlight  on code blocks


Also, the `colorizeCode()` function was updated to move the code block into a `div.highlight` in order to get a same clode block html struct