### PR TITLE
fix broken links in installation docs

### DIFF
--- a/content/documentation/getting_started/installation.md
+++ b/content/documentation/getting_started/installation.md
@@ -174,5 +174,5 @@ If you have a similar output, your Buffalo toolbox is ready to work!
 
 ## Next Steps
 
-* [Tooling Integration](/en/docs/getting-started/integrations) - Work with Buffalo, using existing tools.
-* [Generate a New Project](/en/docs/getting-started/new-project) - Create your first Buffalo project!
+* [Tooling Integration](documentation/getting_started/integrations/) - Work with Buffalo, using existing tools.
+* [Generate a New Project](documentation/getting_started/new-project/) - Create your first Buffalo project!


### PR DESCRIPTION
fix these 2 broken links:
<img width="508" alt="image" src="https://user-images.githubusercontent.com/7100099/161541042-a1094778-8aa4-4645-9dca-35f5eb26ac92.png">
