### PR TITLE
hotfix for nginx redirection issue

### DIFF
--- a/content/documentation/_index.fr.md
+++ b/content/documentation/_index.fr.md
@@ -23,7 +23,7 @@ La couche de persistance du framework Buffalo.
 Request handling and routing. The core of the framework.
 {{< /card >}}
 
-{{< card "card bg-blue-100 mb-4" "Deployment" "documentation/deploy/building">}}
+{{< card "card bg-blue-100 mb-4" "Deployment" "documentation/deploy/packing">}}
 Traitement et routage des demandes. Le cœur du cadre.
 {{< /card >}}
 

--- a/content/documentation/_index.md
+++ b/content/documentation/_index.md
@@ -23,7 +23,7 @@ The persistence layer of the Buffalo framework.
 Request handling and routing. The core of the framework.
 {{< /card >}}
 
-{{< card "card bg-blue-100 mb-4" "Deployment" "documentation/deploy/building">}}
+{{< card "card bg-blue-100 mb-4" "Deployment" "documentation/deploy/packing">}}
 Guides on how to deploy your Buffalo application.
 {{< /card >}}
 

--- a/content/documentation/request_handling/sessions.md
+++ b/content/documentation/request_handling/sessions.md
@@ -84,7 +84,7 @@ Buffalo automatically saves your session for you, so you don't have to. If there
 
 ## Null Sessions for APIs
 
-When building API servers the default cookie session store is undesirable. The [`sessions.Null`](`sessions.Null`) type is the recommended replacement for the default session store.
+When building API servers the default cookie session store is undesirable. The `sessions.Null` type is the recommended replacement for the default session store.
 
 ```go
 app = buffalo.New(buffalo.Options{

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,5 +1,6 @@
 server {
   listen 0.0.0.0:$PORT;
+  port_in_redirect off;
 
   location / {
     root /usr/share/nginx/html;


### PR DESCRIPTION
- force nginx to generate redirect response **without** port number (context: docker port mapping)
- some remained path fixes