### PR TITLE
bugfix: fixing installation path to be correct

### DIFF
--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -9,6 +9,7 @@ document.addEventListener('DOMContentLoaded', () =>{
 
     loadLatestLibVersion();
     loadLatestCliVersion();
+    loadLatestBinaryVersion();
 });
 
 function loadLatestLibVersion() {
@@ -26,6 +27,25 @@ function loadLatestLibVersion() {
     }).then(data => {
         els.forEach(el => {
             el.innerHTML = data.items[0].title;
+        })
+    })
+}
+
+function loadLatestBinaryVersion() {
+    let els = document.querySelectorAll(".latest-cli-binary-version");
+    if (els.length == 0){
+        return
+    }
+
+    fetch(`https://api.rss2json.com/v1/api.json?rss_url=https://github.com/gobuffalo/cli/releases.atom`, {
+        headers: {
+          'Accept': 'application/json'
+        }
+    }).then(response => {
+        return response.json();
+    }).then(data => {
+        els.forEach(el => {
+            el.innerHTML = data.items[0].title.replace("v", "");
         })
     })
 }

--- a/content/documentation/getting_started/installation.md
+++ b/content/documentation/getting_started/installation.md
@@ -62,7 +62,7 @@ Since `v0.10.3`, pre-compiled archives are provided with each release. If you do
 ### GNU / Linux
 
 ```console
-$ wget https://github.com/gobuffalo/cli/releases/download/{{< latestclirelease >}}/buffalo_{{< latestclirelease >}}_Linux_x86_64.tar.gz
+$ wget https://github.com/gobuffalo/cli/releases/download/{{< latestclirelease >}}/buffalo_{{< latestclibinaryversion >}}_Linux_x86_64.tar.gz
 $ tar -xvzf buffalo_{{< latestclirelease >}}_Linux_x86_64.tar.gz
 $ sudo mv buffalo /usr/local/bin/buffalo
 ```
@@ -70,7 +70,7 @@ $ sudo mv buffalo /usr/local/bin/buffalo
 ### MacOS
 
 ```console
-$ curl -OL https://github.com/gobuffalo/cli/releases/download/{{< latestclirelease >}}/buffalo_{{< latestclirelease >}}_Darwin_x86_64.tar.gz
+$ curl -OL https://github.com/gobuffalo/cli/releases/download/{{< latestclirelease >}}/buffalo_{{< latestclibinaryversion >}}_Darwin_x86_64.tar.gz
 $ tar -xvzf buffalo_{{< latestclirelease >}}_Darwin_x86_64.tar.gz
 $ sudo mv buffalo /usr/local/bin/buffalo
 # or if you have ~/bin folder setup in the environment PATH variable

--- a/layouts/shortcodes/latestclibinaryversion.html
+++ b/layouts/shortcodes/latestclibinaryversion.html
@@ -1,0 +1,1 @@
+<span class="latest-cli-binary-version"></span>


### PR DESCRIPTION
This PR separates the way we add the binary version for the installation into another shortcode and js. It should solve #638.