### PR TITLE
showing pages of default language when translated pages are missing

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -11,7 +11,7 @@ languages:
     languageName: English
     languageCode: en-us
     title: 🇬🇧 EN
-    weight: 2
+    weight: 1
     params:
       copyRight: Copyright © 2022 Buffalo. All rights reserved.
       logoCredits: >-
@@ -43,7 +43,7 @@ languages:
     languageName: Français
     languageCode: fr-fr
     title: 🇫🇷 FR
-    weight: 1
+    weight: 2
     params:
       copyRight: Copyright © 2022 Buffalo. Tous droits réservés.
       logoCredits: >-

--- a/layouts/documentation/baseof.html
+++ b/layouts/documentation/baseof.html
@@ -77,12 +77,12 @@
 				{{ partial "languageselector.html" . }}
 
 				<div class="flex md:gap-6">
-					<aside class="bg-gray-200 rounded-md p-7 hidden md:block docssidebar">
+					<aside class="bg-gray-200 rounded-md p-5 pl-3 hidden md:block docssidebar">
 						{{partial "docssidebar" .}}
 					</aside>
 
 					<div class="w-full p-5 md:flex-grow md:p-9 bg-white rounded-md">
-						<div class="max-w-4xl content mt-2">
+						<div class="max-w-4xl md:max-w-3xl content mt-2">
 							{{ block "main" . }}{{end }}
 						</div>
 					</div>

--- a/layouts/partials/docssidebar.html
+++ b/layouts/partials/docssidebar.html
@@ -1,66 +1,39 @@
 {{ $currentPage := . | relLangURL }}
 {{ .Scratch.Set "currentPage" $currentPage }}
-
-<div>
+<div class="min-w-max">
     <ul class="mb-5">
         {{ with .Site.GetPage "section" "documentation" }}
             {{ $section := . }}
-            {{ range .Site.Pages }}     
-                {{ if .InSection $section }}   
+            {{ range .RegularPages | lang.Merge .Sites.First.RegularPages }}
+                {{ if .InSection $section }}
                     {{ $active := eq $currentPage (. | relLangURL)  }}
                     <li class="px-2 py-1.5 {{if $active}} bg-blue-200 rounded-sm border-l border-blue-800 {{end}}">
                         <a href="{{ .RelPermalink }}" class="hover:underline flex items-center">
-                            {{- $image := (resources.Get .Params.Icon) -}} 
+                            {{- $image := (resources.Get .Params.Icon) -}}
                             <img src="{{$image.RelPermalink}}" class="w5 h-5 mr-1.5" alt="page-icon">
                             <span>{{ .Params.Name }}</span>
                         </a>
                     </li>
                 {{ end }}
             {{ end }}
-        {{ end }} 
+        {{ end }}
     </ul>
 
-    {{ with .Site.GetPage "section" "getting_started" }}
-        {{ .Scratch.Set "currentPage" $currentPage }}
-        {{ .Scratch.Set "section" . }}
-
-        {{ partial "sidebargroup" . }}
-    {{ end }}
-
-    {{ with .Site.GetPage "section" "request_handling" }}
-    {{ .Scratch.Set "currentPage" $currentPage }}
-        {{ .Scratch.Set "section" . }}
-
-        {{ partial "sidebargroup" . }}
-    {{ end }}
-
-    {{ with .Site.GetPage "section" "frontend-layer" }}
-        {{ .Scratch.Set "currentPage" $currentPage }}
-        {{ .Scratch.Set "section" . }}
-
-        {{ partial "sidebargroup" . }}
-    {{ end }}
-
-
-    {{ with .Site.GetPage "section" "database" }}
-        {{ .Scratch.Set "currentPage" $currentPage }}
-        {{ .Scratch.Set "section" . }}
-
-        {{ partial "sidebargroup" .}}   
-    {{ end }}
-
-    {{ with .Site.GetPage "section" "guides" }}
-        {{ .Scratch.Set "currentPage" $currentPage }}
-        {{ .Scratch.Set "section" . }}
-
-        {{ partial "sidebargroup" .}}   
-    {{ end }}
-
-    {{ with .Site.GetPage "section" "deploy" }}
-        {{ .Scratch.Set "currentPage" $currentPage }}
-        {{ .Scratch.Set "section" . }}
-
-        {{ partial "sidebargroup" .}}   
+    {{ $site := .Site }}
+    {{ $enSite := .Sites.First }}
+    {{ $sections := slice "getting_started" "request_handling" "frontend-layer" "database" "guides" "deploy" }}
+    {{ range $sect := $sections }}
+        {{ with $site.GetPage "section" . }}
+            {{ .Scratch.Set "currentPage" $currentPage }}
+            {{ .Scratch.Set "section" . }}
+            {{ partial "sidebargroup" . }}
+        {{ else }}
+            {{ with $enSite.GetPage "section" . }}
+                {{ .Scratch.Set "currentPage" $currentPage }}
+                {{ .Scratch.Set "section" . }}
+                {{ partial "sidebargroup" . }}
+            {{ end }}
+        {{ end }}
     {{ end }}
 
 </div>

--- a/layouts/partials/languageselector.html
+++ b/layouts/partials/languageselector.html
@@ -3,7 +3,7 @@
         {{- if .IsTranslated -}}
             <div class="inline-flex items-center gap-3">
             {{- $currentLanguage := .Language -}}
-            {{- range $index, $page := sort .AllTranslations.Reverse -}}
+            {{- range $index, $page := sort .AllTranslations -}}
                 {{ if ne $index 0 }}
                     <span class="border-l-2 h-5"></span>
                 {{- end -}}

--- a/layouts/partials/sidebargroup.html
+++ b/layouts/partials/sidebargroup.html
@@ -1,10 +1,9 @@
 {{ $section := .Scratch.Get "section" }}
 {{ $currentPage := .Scratch.Get "currentPage" }}
-<h2 class="text-gray-800 font-bold">{{ .Title }}</h2>
-<ul class="mb-3 pl-2 py-2">
-    {{ range .Site.Pages }}     
+<h2 class="text-gray-800 font-bold pl-2">{{ .Title }}</h2>
+<ul class="mb-3 pl-4 py-2">
+    {{ range .RegularPages | lang.Merge .Sites.First.RegularPages }}
         {{ $addIt  := .InSection $section }}
-        {{ $addIt  = and $addIt (ne . $section) }}
         {{ if $addIt }}
             {{ $active := eq $currentPage (. | relLangURL)  }}
             <li class="px-2 py-1.5 {{if $active}} bg-blue-200 rounded-sm border-l border-blue-800 {{end}} p-0.5">
@@ -12,4 +11,4 @@
             </li>
         {{ end }}
     {{ end }}
-</ul>     
+</ul>


### PR DESCRIPTION
How about this? Currently, when displaying translated pages, the left-side navigation menu is empty because of the absence of translated pages instead of showing the list of pages for the default language. If there is no intention, I think we should show the English page as default.

This PR changes the default language's weight to 1 and makes the menu shows all default language pages when there is no translated one by using the first (default) language.
It also tweaks the layout slightly to make the width of the menu fixed, and also better looking with a smaller screen (for someone like me)