### PR TITLE
Change: Replace packr with fs

### DIFF
--- a/content/documentation/guides/apis.md
+++ b/content/documentation/guides/apis.md
@@ -23,6 +23,7 @@ $ buffalo new --api coke
 Applications generated with the `--api` flag don't contain any front systems. This means there is no templating, stylesheets, etc...
 
 #### <code>buffalo new coke --api</code>
+
 ```erb
 ├── Dockerfile
 ├── README.md
@@ -46,6 +47,7 @@ Applications generated with the `--api` flag don't contain any front systems. Th
 ```
 
 #### <code>buffalo new coke</code>
+
 ```erb
 ├── Dockerfile
 ├── README.md
@@ -154,8 +156,8 @@ func App() *buffalo.App {
 func init() {
 	r = render.New(render.Options{
 		HTMLLayout:   "application.html",
-		TemplatesFS: templates.FS(),
-		AssetsFS: public.FS(),
+		TemplatesFS:  templates.FS(),
+		AssetsFS: 	  public.FS(),
 		Helpers:      render.Helpers{},
 	})
 }

--- a/content/documentation/guides/apis.md
+++ b/content/documentation/guides/apis.md
@@ -157,7 +157,7 @@ func init() {
 	r = render.New(render.Options{
 		HTMLLayout:   "application.html",
 		TemplatesFS:  templates.FS(),
-		AssetsFS: 	  public.FS(),
+		AssetsFS:     public.FS(),
 		Helpers:      render.Helpers{},
 	})
 }

--- a/content/documentation/guides/apis.md
+++ b/content/documentation/guides/apis.md
@@ -144,7 +144,7 @@ func App() *buffalo.App {
 		app.Use(middleware.PopTransaction(models.DB))
 		app.Use(translations())
 		app.GET("/", HomeHandler)
-		app.ServeFiles("/", assetsBox) // serve files from the public directory
+		app.ServeFiles("/", http.FS(public.FS())) // serve files from the public directory
 	}
 	return app
 }
@@ -154,8 +154,8 @@ func App() *buffalo.App {
 func init() {
 	r = render.New(render.Options{
 		HTMLLayout:   "application.html",
-		TemplatesBox: packr.NewBox("../templates"),
-		AssetsBox:    assetsBox,
+		TemplatesFS: templates.FS(),
+		AssetsFS: public.FS(),
 		Helpers:      render.Helpers{},
 	})
 }


### PR DESCRIPTION
This PR updates the file difference for normal project and api project to fs rather than packr.

Signed-off-by: Yasin Kinyua Murithi <yasinkinyua@gmail.com>