### PR TITLE
Update getting started docs and fix documentation layout

### DIFF
--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -97,7 +97,7 @@ html {
 }
 
 .content code {
-    @apply break-all;
+    @apply bg-gray-100 p-1 rounded-md text-base;
 }
 
 .content .card h4 {

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -56,10 +56,6 @@ html {
     background-color: #FFFBF9;
 }
 
-.docssidebar {
-    width: 350px;
-}
-
 .content {
     overflow: wrap;
 }
@@ -96,7 +92,7 @@ html {
     @apply p-3 overflow-scroll;
 }
 
-.content p code, li code {
+.content p code, li code, table code {
     @apply bg-gray-200 p-1 rounded-md text-base;
 }
 

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -92,11 +92,11 @@ html {
     @apply p-3 overflow-scroll;
 }
 
-.content p code, li code, table code {
+.content p code, li code {
     @apply bg-gray-200 p-1 rounded-md text-base;
 }
 
-.content code {
+table code {
     @apply bg-gray-100 p-1 rounded-md text-base;
 }
 

--- a/content/documentation/getting_started/configuration.md
+++ b/content/documentation/getting_started/configuration.md
@@ -1,7 +1,7 @@
 ---
 name: Configuration
 seoDescription: "Handle configuration with Buffalo"
-seoKeywords: 
+seoKeywords:
   - "buffalo"
   - "go"
   - "golang"
@@ -28,14 +28,14 @@ The following variables are used by Buffalo:
 
 | Variable                 | Default                  | Usage                                                      |
 | ---                      | ---                      | ---                                                        |
-| `GO_ENV`                 | `development`            | The environment (dev, qa, production etc.) that Buffalo is run in                   |
-| `GO_BIN`                 | `go`                     | The Go compiler to use                                     |
-| `BUFFALO_PLUGIN_PATH`    | `$PATH`                  | Where Buffalo looks for plugins                            |
-| `BUFFALO_PLUGIN_TIMEOUT` | `1s`                     | How long Buffalo waits for a plugin to respond             |
-| `ADDR`                   | `127.0.0.1` or `0.0.0.0` | Which address to bind the server to                        |
-| `PORT`                   | `3000`                   | Which port to bind the server to                           |
-| `HOST`                   | `http://127.0.0.1:$PORT` | The "URL" of the application (i.e. what end users type in) |
-| `SESSION_SECRET`         | `""`                     | A salt used for securing sessions                          |
+| `GO_ENV`                 | `development`            | The environment (dev, qa, production etc.) that Buffalo is run in.                   |
+| `GO_BIN`                 | `go`                     | The Go compiler to use.                                     |
+| `BUFFALO_PLUGIN_PATH`    | `$PATH`                  | Where Buffalo looks for plugins.                            |
+| `BUFFALO_PLUGIN_TIMEOUT` | `1s`                     | How long Buffalo waits for a plugin to respond.             |
+| `ADDR`                   | `127.0.0.1` or `0.0.0.0` | Which address to bind the server to.                        |
+| `PORT`                   | `3000`                   | Which port to bind the server to.                           |
+| `HOST`                   | `http://127.0.0.1:$PORT` | The "URL" of the application (i.e. what end users type in). |
+| `SESSION_SECRET`         | `""`                     | A salt used for securing sessions.                          |
 
 ## Custom Configuration
 
@@ -71,3 +71,7 @@ APP_URL=https://myapp.com
 ```
 
 Generated apps (**with buffalo >= 0.10.3**) will also create a default `.env` file in your application root. This file will be watched by Buffalo for changes, but will be ignored by git (added in the `.gitignore`). This is a good way to prevent developers to push credentials by mistake.
+
+## Next Steps
+
+* [Tooling Integration](/documentation/getting_started/integrations) - Work with Buffalo, using existing tools.

--- a/content/documentation/getting_started/directory-structure.md
+++ b/content/documentation/getting_started/directory-structure.md
@@ -25,27 +25,47 @@ Now that you have a minimal new project, let's go through its contents.
 
 Here is the structure of a Buffalo project:
 
-
-* `go/` &mdash; GOPATH root.
-	* `src/` &mdash; Go sources directory
-		* `github.com/username/myapp/` &mdash; your app root
-			* `actions/`
-			* `assets/`
-			* `grifts/`
-			* `locales/`
-			* `models/`
-			* `public/`
-			* `templates/`
-			* `tmp/`
-			* `database.yml`
-			* `main.go`
+``` erb
+├── actions/
+│	├── app.go
+│	└── render.go
+├── assets/
+├── cmd/
+│	└── app/
+│		└── main.go
+├── config/
+├── fixtures/
+├── grifts/
+├── locales/
+├── models/
+├── public/
+├── templates/
+├── .babelrc
+├── .buffalo.dev.yml
+├── .codeclimate.yml
+├── .docketignore
+├── .env
+├── .gitignore
+├── .pnp.loader.mjs
+├── .yarnrc.yml
+├── database.yml
+├── Dockerfile
+├── go.mod
+├── go.sum
+├── inflections.json
+├── package.json
+├── postcss.config.js
+├── README.md
+├── webpack.config.js
+└── yarn.lock
+```
 
 ### actions
 
 This directory handles the **Controller** part of the MVC pattern. It contains the handlers for your URLs, plus:
 
-* the `app.go` file to setup your app & routes,
-* the `render.go` file to setup the template engine(s).
+* The `app.go` file to setup your app & routes,
+* The `render.go` file to setup the template engine(s).
 
 ### assets
 
@@ -54,6 +74,10 @@ This directory is optional. If you don't need to use a frontend setup (API only,
 {{< /note >}}
 
 This directory contains **raw** assets which will be compiled/compressed & put in the [`public`](#public) directory.
+
+### cmd
+
+This folder contains the `main.go` file which bootstraps your app and starts it.
 
 ### grifts
 
@@ -115,10 +139,7 @@ This file is optional. If you don't need a database, or if you want to handle th
 
 This file contains the database configuration for [pop/soda](https://github.com/gobuffalo/pop).
 
-### main.go
-
-This file bootstraps your app and starts it.
-
 ## Next Steps
 
 * [Configuration](/documentation/getting_started/configuration) - Manage your app configuration.
+* [Tooling Integration](/documentation/getting_started/integrations) - Work with Buffalo, using existing tools.

--- a/content/documentation/getting_started/installation.md
+++ b/content/documentation/getting_started/installation.md
@@ -177,5 +177,4 @@ If you have a similar output, your Buffalo toolbox is ready to work!
 
 ## Next Steps
 
-* [Tooling Integration](/documentation/getting_started/integrations) - Work with Buffalo, using existing tools.
 * [Generate a New Project](/documentation/getting_started/new-project) - Create your first Buffalo project!

--- a/content/documentation/getting_started/installation.md
+++ b/content/documentation/getting_started/installation.md
@@ -35,7 +35,6 @@ Buffalo is currently available and tested on the following platforms:
 Before installing make sure you have the required dependencies installed:
 
 * [A working Go environment](http://gopherguides.com/before-you-come-to-class)
-* [A configured `$PATH` environment variable that includes `$GOPATH/bin`.](https://golang.org/doc/code.html#GOPATH)
 * [Go](https://golang.org) version `{{< mingoversion >}}`.
 
 ##### Frontend Requirements
@@ -114,8 +113,6 @@ $ gofish install buffalo
 ## Custom Installation **with** SQLite3 Support
 
 **SQLite 3** requires a GCC, or equivalent C compiler for [mattn/go-sqlite3](https://github.com/mattn/go-sqlite3) to compile. You **must** have a GCC installed **first** before installing Buffalo.
-
-To install Buffalo, ensure your `GOPATH` is defined, then:
 
 ```sh
 $ go install -tags sqlite github.com/gobuffalo/cli/cmd/buffalo@{{< latestclirelease >}}

--- a/content/documentation/getting_started/integrations.md
+++ b/content/documentation/getting_started/integrations.md
@@ -28,6 +28,10 @@ If you use `zsh` shell, you can use this plugin, created by [@1995parham](https:
 
 If you use `bash` shell, you can try this script, created by [@cippaciong](https://github.com/cippaciong), which provides basic autocompletion: https://github.com/cippaciong/buffalo_bash_completion
 
+## Go extension for Visual Studio Code
+
+If you use `Visual Studio Code` as code editor, you can try this extension: [Go](https://code.visualstudio.com/docs/languages/go).
+
 ## Next Steps
 
 * [Generate a New Project](/documentation/getting_started/new-project) - Create your first Buffalo project!

--- a/content/documentation/getting_started/new-project.md
+++ b/content/documentation/getting_started/new-project.md
@@ -1,7 +1,7 @@
 ---
 name: Generating a New Project
 seoDescription: "Generate a new Buffalo project"
-seoKeywords: 
+seoKeywords:
   - "buffalo"
   - "go"
   - "golang"
@@ -17,19 +17,13 @@ aliases:
 
 # Generating a New Project
 
-You now have a working Buffalo installation. In this section, you will learn how to create **a brand new web application**, using the `buffalo` command. 
+You now have a working Buffalo installation. In this section, you will learn how to create **a brand new web application**, using the `buffalo` command.
 
 ## Create a New Project
 
 Buffalo aims to make building new web applications in Go as **quick and simple** as possible. What could be more simple than a *new application* generator?
 
-Start by going to your `$GOPATH` and create your new application!
-
-```bash
-$ cd $GOPATH/src/github.com/$USER/
-```
-
-Make sure `$GOPATH/bin` is in your `$PATH`, then:
+Start by going to your preferred folder where you want to place your project, then:
 
 ```bash
 $ buffalo new coke
@@ -43,65 +37,162 @@ That will generate a whole new Buffalo application called **coke**, all ready to
 
 ```bash
 $ buffalo new coke
-Buffalo version {{< latestclirelease >}}
+DEBU[2022-05-25T11:06:33-05:00] Step: 435aea40
+DEBU[2022-05-25T11:06:33-05:00] Chdir: /your/path/coke
+DEBU[2022-05-25T11:06:33-05:00] Exec: go mod init coke
+go: creating new go.mod: module coke
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/README.md
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/actions/actions_test.go
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/actions/app.go
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/actions/home.go
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/actions/home_test.go
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/actions/render.go
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/cmd/app/main.go
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/.codeclimate.yml
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/.env
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/fixtures/sample.toml
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/grifts/init.go
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/inflections.json
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/config/buffalo-app.toml
+DEBU[2022-05-25T11:06:33-05:00] Step: 638bde0d
+DEBU[2022-05-25T11:06:33-05:00] Chdir: /your/path/coke
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/Dockerfile
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/.dockerignore
+DEBU[2022-05-25T11:06:33-05:00] Step: 7065092d
+DEBU[2022-05-25T11:06:33-05:00] Chdir: /your/path/coke
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/grifts/db.go
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/models/models.go
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/models/models_test.go
+DEBU[2022-05-25T11:06:33-05:00] Step: 916dfca0
+DEBU[2022-05-25T11:06:33-05:00] Chdir: /your/path/coke
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/database.yml
+DEBU[2022-05-25T11:06:33-05:00] Step: ff1c6d38
+DEBU[2022-05-25T11:06:33-05:00] Chdir: /your/path/coke
+DEBU[2022-05-25T11:06:33-05:00] File: /your/path/coke/.buffalo.dev.yml
+DEBU[2022-05-25T11:06:33-05:00] Step: 103396c6
+DEBU[2022-05-25T11:06:33-05:00] Chdir: /your/path/coke
+DEBU[2022-05-25T11:06:33-05:00] Exec: go install github.com/gobuffalo/buffalo-pop/v3@latest
+DEBU[2022-05-25T11:06:34-05:00] Step: ae1260b1
+DEBU[2022-05-25T11:06:34-05:00] Chdir: /your/path/coke
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/config/buffalo-plugins.toml
+DEBU[2022-05-25T11:06:34-05:00] Step: 4992ff46
+DEBU[2022-05-25T11:06:34-05:00] Chdir: /your/path/coke
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/actions/app.go
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/actions/home.go
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/actions/home_test.go
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/actions/render.go
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/locales/all.en-us.yaml
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/locales/embed.go
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/public/embed.go
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/public/robots.txt
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/templates/_flash.plush.html
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/templates/application.plush.html
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/templates/embed.go
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/templates/home/index.plush.html
+DEBU[2022-05-25T11:06:34-05:00] Step: 69d71878
+DEBU[2022-05-25T11:06:34-05:00] Chdir: /your/path/coke
+DEBU[2022-05-25T11:06:34-05:00] LookPath: yarn
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/assets/css/_buffalo.scss
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/assets/css/application.scss
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/assets/images/favicon.ico
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/assets/images/logo.svg
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/assets/js/application.js
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/.babelrc
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/package.json
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/postcss.config.js
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/public/assets/keep
+DEBU[2022-05-25T11:06:34-05:00] File: /your/path/coke/webpack.config.js
+DEBU[2022-05-25T11:06:34-05:00] LookPath: yarn
+DEBU[2022-05-25T11:06:34-05:00] Exec: yarn --version
+1.22.17
+DEBU[2022-05-25T11:06:34-05:00] Exec: yarn set version berry
+➤ YN0000: Retrieving https://repo.yarnpkg.com/3.2.1/packages/yarnpkg-cli/bin/yarn.js
+➤ YN0000: Saving the new release in .yarn/releases/yarn-3.2.1.cjs
+➤ YN0000: Done in 0s 637ms
+DEBU[2022-05-25T11:06:37-05:00] Exec: yarn config set enableGlobalCache true
+➤ YN0000: Successfully set enableGlobalCache to true
+DEBU[2022-05-25T11:06:37-05:00] Exec: yarn config set logFilters --json [{"code":"YN0013","level":"discard"}]
+➤ YN0000: Successfully set logFilters to [
+  {
+    code: 'YN0013',
+    text: undefined,
+    pattern: undefined,
+    level: 'discard'
+  }
+]
+DEBU[2022-05-25T11:06:37-05:00] Exec: yarn --version
+3.2.1
+DEBU[2022-05-25T11:06:38-05:00] Exec: yarn install
+DEBU[2022-05-25T11:06:38-05:00] ➤ YN0000: ┌ Resolution step
 
-      create  .buffalo.dev.yml
-      create  assets/images/logo.svg
-      create  assets/css/application.scss
-      create  assets/images/favicon.ico
-      create  assets/js/application.js
-      create  .babelrc
-      create  package.json
-      create  public/assets/.keep
-      create  webpack.config.js
-         run  yarn install --no-progress --save
-yarn install v0.27.5
-info No lockfile found.
-[1/4] Resolving packages...
-[2/4] Fetching packages...
-[3/4] Linking dependencies...
-[4/4] Building fresh packages...
-success Saved lockfile.
-Done in 11.71s.
-      create  models/models.go
-      create  models/models_test.go
-      create  grifts/db.go
-         run  go get github.com/gobuffalo/pop/...
-      create  ./database.yml
-         run  goimports -w coke/grifts/db.go coke/models/models.go coke/models/models_test.go
-      create  Dockerfile
-      create  .dockerignore
-         run  go get -u golang.org/x/tools/cmd/goimports
-      create  README.md
-      create  actions/actions_test.go
-      create  actions/app.go
-      create  actions/home.go
-      create  actions/home_test.go
-      create  actions/render.go
-      create  .codeclimate.yml
-      create  .env
-      create  grifts/init.go
-      create  inflections.json
-      create  locales/all.en-us.yaml
-      create  main.go
-      create  public/robots.txt
-      create  templates/_flash.html
-      create  templates/application.html
-      create  templates/index.html
-         run  go get -t ./...
-         run  goimports -w actions/actions_test.go actions/app.go actions/home.go actions/home_test.go actions/render.go grifts/db.go grifts/init.go main.go models/models.go models/models_test.go
-      create  .gitignore
-         run  git init
-Initialized empty Git repository in /Users/markbates/Dropbox/development/gocode/src/github.com/markbates/coke/.git/
-         run  git add .
-         run  git commit -q -m Initial Commit
-INFO[0055] Congratulations! Your application, coke, has been successfully built!
+DEBU[2022-05-25T11:06:39-05:00] ➤ YN0032: │ fsevents@npm:2.3.2: Implicit dependencies on node-gyp are discouraged
 
- 
-INFO[0055] You can find your new application at:
-/Users/markbates/Dropbox/development/gocode/src/github.com/markbates/coke 
-INFO[0055] 
-Please read the README.md file in your new application for next steps on running your application.
+DEBU[2022-05-25T11:06:43-05:00] ➤ YN0000: └ Completed in 5s 401ms
+
+DEBU[2022-05-25T11:06:43-05:00] ➤ YN0000: ┌ Fetch step
+
+DEBU[2022-05-25T11:06:43-05:00] ➤ YN0000: └ Completed
+
+DEBU[2022-05-25T11:06:43-05:00] ➤ YN0000: ┌ Link step
+
+DEBU[2022-05-25T11:06:44-05:00] ➤ YN0000: │ ESM support for PnP uses the experimental loader API and is therefore experimental
+
+DEBU[2022-05-25T11:06:44-05:00] ➤ YN0007: │ @fortawesome/fontawesome-free@npm:5.15.4 must be built because it never has been before or the last one failed
+
+DEBU[2022-05-25T11:06:44-05:00] ➤ YN0000: └ Completed in 0s 906ms
+
+DEBU[2022-05-25T11:06:44-05:00] ➤ YN0000: Done with warnings in 6s 462ms
+
+DEBU[2022-05-25T11:06:44-05:00] Step: bb3c28ed
+DEBU[2022-05-25T11:06:44-05:00] Chdir: /your/path/coke
+DEBU[2022-05-25T11:06:44-05:00] Exec: go mod tidy
+go: finding module for package github.com/gobuffalo/buffalo
+go: finding module for package github.com/gobuffalo/mw-paramlogger
+go: finding module for package github.com/gobuffalo/buffalo-pop/v3/pop/popmw
+go: finding module for package github.com/gobuffalo/mw-i18n/v2
+go: finding module for package github.com/gobuffalo/buffalo/render
+go: finding module for package github.com/gobuffalo/mw-forcessl
+go: finding module for package github.com/gobuffalo/envy
+go: finding module for package github.com/gobuffalo/mw-csrf
+go: finding module for package github.com/unrolled/secure
+go: finding module for package github.com/markbates/grift/grift
+go: finding module for package github.com/gobuffalo/pop/v6
+go: finding module for package github.com/gobuffalo/suite/v4
+go: found github.com/gobuffalo/buffalo in github.com/gobuffalo/buffalo v0.18.7
+go: found github.com/gobuffalo/buffalo-pop/v3/pop/popmw in github.com/gobuffalo/buffalo-pop/v3 v3.0.3
+go: found github.com/gobuffalo/buffalo/render in github.com/gobuffalo/buffalo v0.18.7
+go: found github.com/gobuffalo/envy in github.com/gobuffalo/envy v1.10.1
+go: found github.com/gobuffalo/mw-csrf in github.com/gobuffalo/mw-csrf v1.0.0
+go: found github.com/gobuffalo/mw-forcessl in github.com/gobuffalo/mw-forcessl v0.0.0-20220514125302-be60179938a4
+go: found github.com/gobuffalo/mw-i18n/v2 in github.com/gobuffalo/mw-i18n/v2 v2.0.1
+go: found github.com/gobuffalo/mw-paramlogger in github.com/gobuffalo/mw-paramlogger v1.0.0
+go: found github.com/unrolled/secure in github.com/unrolled/secure v1.10.0
+go: found github.com/markbates/grift/grift in github.com/markbates/grift v1.5.0
+go: found github.com/gobuffalo/pop/v6 in github.com/gobuffalo/pop/v6 v6.0.3
+go: found github.com/gobuffalo/suite/v4 in github.com/gobuffalo/suite/v4 v4.0.2
+DEBU[2022-05-25T11:06:45-05:00] Exec: go mod download
+DEBU[2022-05-25T11:06:46-05:00] Step: 218a906c
+DEBU[2022-05-25T11:06:46-05:00] Chdir: /your/path/coke
+DEBU[2022-05-25T11:06:46-05:00] Step: a3cee09e
+DEBU[2022-05-25T11:06:46-05:00] Chdir: /your/path/coke
+DEBU[2022-05-25T11:06:46-05:00] File: /your/path/coke/.gitignore
+DEBU[2022-05-25T11:06:46-05:00] Exec: git init
+hint: Using 'master' as the name for the initial branch. This default branch name
+hint: is subject to change. To configure the initial branch name to use in all
+hint: of your new repositories, which will suppress this warning, call:
+hint:
+hint: 	git config --global init.defaultBranch <name>
+hint:
+hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
+hint: 'development'. The just-created branch can be renamed via this command:
+hint:
+hint: 	git branch -m <name>
+Initialized empty Git repository in /your/path/coke/.git/
+DEBU[2022-05-25T11:06:46-05:00] Exec: git add .
+DEBU[2022-05-25T11:06:46-05:00] Exec: git commit -q -m Initial Commit
+INFO[2022-05-25T11:06:46-05:00] Congratulations! Your application, coke, has been successfully generated!
+INFO[2022-05-25T11:06:46-05:00] You can find your new application at: /your/path/coke
+INFO[2022-05-25T11:06:46-05:00] Please read the README.md file in your new application for next steps on running your application.
 ```
 
 
@@ -109,7 +200,7 @@ Please read the README.md file in your new application for next steps on running
 
 The default setup is great, but maybe it doesn't fit you. Buffalo provides several options as flags for the `new` command.
 
-You can get the available flags list using the `help` command: 
+You can get the available flags list using the `help` command:
 
 ```bash
 $ buffalo help new
@@ -122,13 +213,13 @@ Flags:
       --api                  skip all front-end code and configure for an API server
       --ci-provider string   specify the type of ci file you would like buffalo to generate [none, travis, gitlab-ci, circleci] (default "none")
       --config string        config file (default is $HOME/.buffalo.yaml)
-      --db-type string       specify the type of database you want to use [cockroach, mariadb, mysql, postgres] (default "postgres")
-      --docker string        specify the type of Docker file to generate [none, multi, standard] (default "multi")
+      --db-type string       specify the type of database you want to use [cockroach, mariadb, mysql, postgres, sqlite3] (default "postgres")
   -d, --dry-run              dry run
   -f, --force                delete and remake if the app already exists
   -h, --help                 help for new
       --module string        specify the root module (package) name. [defaults to 'automatic']
       --skip-config          skips using the config file
+      --skip-docker          skips generating the Dockerfile
       --skip-pop             skips adding pop/soda to your app
       --skip-webpack         skips adding Webpack to your app
       --skip-yarn            use npm instead of yarn for frontend dependencies management
@@ -186,4 +277,3 @@ You can also take a look at the [Env Variables](/documentation/getting_started/c
 ## Next Steps
 
 * [Directory Structure](/documentation/getting_started/directory-structure) - Learn more about Buffalo structure.
-* [Configuration](/documentation/getting_started/configuration) - Manage your app configuration.

--- a/layouts/documentation/baseof.html
+++ b/layouts/documentation/baseof.html
@@ -77,13 +77,17 @@
 				{{ partial "languageselector.html" . }}
 
 				<div class="flex md:gap-6">
-					<aside class="bg-gray-200 rounded-md p-5 pl-3 hidden md:block docssidebar">
-						{{partial "docssidebar" .}}
+					<aside class="hidden md:block">
+						<div class="bg-gray-200 rounded-md p-5 pl-3 ">
+							{{partial "docssidebar" .}}
+						</div>
 					</aside>
 
-					<div class="w-full p-5 md:flex-grow md:p-9 bg-white rounded-md">
-						<div class="max-w-4xl md:max-w-3xl content mt-2">
-							{{ block "main" . }}{{end }}
+					<div class="overflow-x-auto md:flex-grow">
+						<div class="bg-white rounded-md p-5 md:p-9 mx-6 md:mx-0">
+							<div class="content mt-2">
+								{{ block "main" . }}{{end }}
+							</div>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
I updated the following getting started docs:

Install Buffalo:
- I removed unneded `$GOPATH` information

Generating a New Project:
- I removed unneded `$GOPATH` information
- I updated the `buffalo new coke` output information
- I updated the `buffalo help new` output information
- I removed the `Configuration` next step link

Directory structure:
- I updated the structure of a Buffalo project
- I added a little `cmd` information.

Configuration
- I added the `Next Steps` section

Tooling Integration
- I added information about go extension for visual studio code


Besides, I adjusted the documentation layout in order to fill the content into box
