### PR TITLE
Link Slack button to documentation section

### DIFF
--- a/content/documentation/support.es.md
+++ b/content/documentation/support.es.md
@@ -9,6 +9,15 @@ aliases:
 
 Si estas buscando soporte, [entrenamiento](https://www.gopherguides.com/in-person-training/), o [consultoría](https://www.gopherguides.com/consulting/) para tu proyecto de Buffalo, [Gopher Guides](https://www.gopherguides.com) (fundado por Mark Bates - fundador de Buffalo) son los formadores y consultores oficiales del ecosistema de Buffalo.
 
+## Comunidad {#community}
+
+The `#buffalo` Slack channel on [gophers.slack.com](https://gophers.slack.com/messages/buffalo/) is great place to ask for help from a variety of Buffalo developers and Gophers.
+
+In order to access the Gophers Slack, and the `#buffalo` channel, you first need to get an invitation. This can be done by going to [https://invite.slack.golangbridge.org/](https://invite.slack.golangbridge.org/) and requesting an invitation.
+
+Once you're in Slack, please join the `#buffalo` channel and say "Hello"! We'd love to hear from you.
+
+Además de la documentación, también puedes ponerte en contacto con nosotros en nuestras cuentas de [GitHub](https://github.com/gobuffalo/buffalo) o [Twitter](https://twitter.com/gobuffalo).
 
 ## Auditoria en proyectos de Buffalo
 

--- a/content/documentation/support.fr.md
+++ b/content/documentation/support.fr.md
@@ -9,6 +9,16 @@ aliases:
 
 Si vous recherchez de l'aide, une [formation](https://www.gopherguides.com/in-person-training/) ou une [consultation](https://www.gopherguides.com/consulting/) pour votre Buffalo projet, les [Gopher Guides](https://www.gopherguides.com) (fondé par Mark Bates - fondateur de Buffalo) sont les formateurs et consultants officiels de l'écosystème Buffalo.
 
+## Communauté {#community}
+
+Les canaux Slack `#buffalo_fr` et `#buffalo` (en anglais) sur [gophers.slack.com](https://gophers.slack.com/messages/buffalo/) sont de bon endroits pour demander de l'aide : de nombreux développeurs Buffalo et autres Gophers s'y trouvent.
+
+Pour pouvoir accéder au Slack Gophers, ainsi qu'aux canaux `#buffalo_fr` et `#buffalo`, vous devez d'abord obtenir une invitation. Pour se faire, rendez-vous sur [https://gophersinvite.herokuapp.com](https://gophersinvite.herokuapp.com) et demandez une invitation.
+
+Une fois sur Slack, rejoignez le canal `#buffalo_fr` et dîtes bonjour. Nous vous attendons !
+
+Outre la documentation elle-même, vous pouvez également nous contacter sur nos comptes [GitHub](https://github.com/gobuffalo/buffalo) ou [Twitter](https://twitter.com/gobuffalo).
+
 ## Audit du projet Buffalo
 
 Que vous lanciez votre premier projet Buffalo ou que vous vous prépariez à en lancer un, demandez aux [Gopher Guides](https://www.gopherguides.com) d'auditer le code pour vous assurer que vous réussissez. Voici quelques-unes des choses qu'un audit vous apporte :

--- a/content/documentation/support.fr.md
+++ b/content/documentation/support.fr.md
@@ -13,7 +13,7 @@ Si vous recherchez de l'aide, une [formation](https://www.gopherguides.com/in-pe
 
 Les canaux Slack `#buffalo_fr` et `#buffalo` (en anglais) sur [gophers.slack.com](https://gophers.slack.com/messages/buffalo/) sont de bon endroits pour demander de l'aide : de nombreux développeurs Buffalo et autres Gophers s'y trouvent.
 
-Pour pouvoir accéder au Slack Gophers, ainsi qu'aux canaux `#buffalo_fr` et `#buffalo`, vous devez d'abord obtenir une invitation. Pour se faire, rendez-vous sur [https://gophersinvite.herokuapp.com](https://gophersinvite.herokuapp.com) et demandez une invitation.
+Pour pouvoir accéder au Slack Gophers, ainsi qu'aux canaux `#buffalo_fr` et `#buffalo`, vous devez d'abord obtenir une invitation. Pour ce faire, rendez-vous sur [https://gophersinvite.herokuapp.com](https://gophersinvite.herokuapp.com) et demandez une invitation.
 
 Une fois sur Slack, rejoignez le canal `#buffalo_fr` et dîtes bonjour. Nous vous attendons !
 

--- a/content/documentation/support.md
+++ b/content/documentation/support.md
@@ -9,6 +9,17 @@ aliases:
 
 If you are looking for support, [training](https://www.gopherguides.com/in-person-training/), or [consulting](https://www.gopherguides.com/consulting/) for your Buffalo project, the [Gopher Guides](https://www.gopherguides.com) (founded by Mark Bates - founder of Buffalo) are the official trainers and consultants for the Buffalo ecosystem.
 
+## Community {#community}
+
+The `#buffalo` Slack channel on [gophers.slack.com](https://gophers.slack.com/messages/buffalo/) is great place to ask for help from a variety of Buffalo developers and Gophers.
+
+In order to access the Gophers Slack, and the `#buffalo` channel, you first need to get an invitation. This can be done by going to [https://invite.slack.golangbridge.org/](https://invite.slack.golangbridge.org/) and requesting an invitation.
+
+Once you're in Slack, please join the `#buffalo` channel and say "Hello"! We'd love to hear from you.
+
+Besides the documentation itself, you can also get in touch with us on our [GitHub](https://github.com/gobuffalo/buffalo) or [Twitter](https://twitter.com/gobuffalo) accounts.
+
+
 ## Buffalo Project Audit
 
 Whether you are starting your first Buffalo project, or getting ready to launch one, have the [Gopher Guides](https://www.gopherguides.com) audit the code to make sure you are successful. Here are just some of the things an audit gets you:

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,7 +3,7 @@
         <span class="text-white">
             <a href="{{ .Site.Home.RelPermalink | relLangURL }}" class="inline">
                 <span class="flex flex-row items-center">
-                    {{- $image := (resources.Get "images/logo_top.png").Resize "150x webp" -}}  
+                    {{- $image := (resources.Get "images/logo_top.png").Resize "150x webp" -}}
                     <img src="{{$image.RelPermalink}}" alt="logo" class="w-6 sm:w-10 mr-1 sm:mr-2"/>
                     <span class="text-xl sm:text-2xl font-medium">Buffalo</span>
                 </span>
@@ -11,16 +11,16 @@
         </span>
 
         <span class="flex flex-row gap-1">
-            <a href="https://gophers.slack.com/messages/buffalo/" class="p-2 hover:bg-blue-800 rounded-full">
-                {{- $image := (resources.Get "images/slack.png") -}}  
+            <a href="{{ "documentation/support/#community" | relLangURL }}" class="p-2 hover:bg-blue-800 rounded-full">
+                {{- $image := (resources.Get "images/slack.png") -}}
                 <img src="{{$image.RelPermalink}}" alt="slack logo" class="w-6 h-6 sm:w-7 sm:h-7">
             </a>
 
             <a href="https://github.com/gobuffalo/buffalo" class="text-white hover:opacity-95 hover:bg-blue-800 p-2 rounded-full">
                 <svg viewBox="0 0 16 16" class="w-6 h-6 sm:w-7 sm:h-7" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"></path></svg>
-            </a>					
+            </a>
         </span>
-        
+
         <ul class="hidden md:flex flex-grow justify-end flex-row space-x-5 text-white ">
             {{ $currentPage := . }}
             {{ range .Site.Menus.top }}
@@ -40,7 +40,7 @@
                 <span class="flex-auto">{{.Site.Params.SearchButtonText}}</span><kbd class="font-sans font-semibold dark:text-slate-500"><abbr title="Command" class="no-underline text-slate-300 dark:text-slate-500">⌘</abbr> K</kbd>
             </button>
         </span>
-        <span class="flex flex-row flex-grow md:hidden text-white justify-end"> 
+        <span class="flex flex-row flex-grow md:hidden text-white justify-end">
             <a href="#" id="mobile-menu-control" class="hover:bg-gray-700 p-1.5 rounded-md ">
                 <svg class="w-8 h-8" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
             </a>
@@ -70,6 +70,6 @@
             </div>
         {{ end }}
     </div>
-    
+
 </div>
 


### PR DESCRIPTION
I wanted to join the Slack community, but the button sent me to a Slack sign-in page without instructions.

I did not know I had to receive an invitation / sign-up first, and then I could login.

It could be confusing for newcomers too, so I thought the best was to add back the section from the old website.

Let me know what you think, and if I can improve anything else 🙇 

> **Warning**
> The ES 🇪🇸 translation is missing