### PR TITLE
Add Factory Worker adapter link

### DIFF
--- a/content/documentation/guides/workers.md
+++ b/content/documentation/guides/workers.md
@@ -45,6 +45,7 @@ The following Worker implementations are provided by Buffalo users (no official 
 | Name | Author | Description |
 |:------|:--------|:-------------|
 | [AMQP worker adapter](https://github.com/stanislas-m/amqp-work-adapter) | [@stanislas-m](https://github.com/stanislas-m) | A Worker implementation to use with AMQP-compatible brokers (such as [RabbitMQ](https://www.rabbitmq.com/)). |
+| [Faktory worker adapter](https://github.com/frankywahl/fwa) | [@frankywahl](https://github.com/frankywahl) | A Worker implementation to use with [Faktory](https://contribsys.com/faktory/). |
 
 ## The Job type
 


### PR DESCRIPTION
I've created an adapter for using [Faktory](https://contribsys.com/faktory/) as a worker adapter. I thought I'd share it here if somebody want to use it. 

### What is being done in this PR?
Adding an adapter for the Worker API

### List the manual test cases you've covered before sending this PR:
I ran in on a personal project using the repository