### PR TITLE
fix: twitter link

### DIFF
--- a/content/documentation/_index.es.md
+++ b/content/documentation/_index.es.md
@@ -34,4 +34,4 @@ Guías sobre cómo implementar tu aplicación en Buffalo.
 
 La comunidad de Buffalo es una comunidad vibrante y en crecimiento de desarrolladores y usuarios. Hay una conversación en curso sobre consejos y trucos, nuevas características e ideas que tiene lugar en [Gophers Slack #buffalo channel](https://gophers.slack.com/messages/buffalo/).
 
-Además de la documentación, también puedes ponerte en contacto con nosotros en nuestras cuentas de [GitHub](https://github.com/gobuffalo/buffalo) o [Twitter](https://twitter.com/gobuffalo).
+Además de la documentación, también puedes ponerte en contacto con nosotros en nuestras cuentas de [GitHub](https://github.com/gobuffalo/buffalo) o [Twitter](https://twitter.com/gobuffalo_io).

--- a/content/documentation/_index.fr.md
+++ b/content/documentation/_index.fr.md
@@ -33,4 +33,4 @@ Traitement et routage des demandes. Le cœur du cadre.
 
 La communauté Buffalo est une communauté dynamique et croissante de développeurs et d'utilisateurs. Il y a une conversation en cours sur les trucs et astuces, les nouvelles fonctionnalités et les idées qui ont lieu dans le [Gophers Slack #buffalo channel](https://gophers.slack.com/messages/buffalo/).
 
-Outre la documentation elle-même, vous pouvez également nous contacter sur nos comptes [GitHub](https://github.com/gobuffalo/buffalo) ou [Twitter](https://twitter.com/gobuffalo).
+Outre la documentation elle-même, vous pouvez également nous contacter sur nos comptes [GitHub](https://github.com/gobuffalo/buffalo) ou [Twitter](https://twitter.com/gobuffalo_io).

--- a/content/documentation/_index.md
+++ b/content/documentation/_index.md
@@ -34,4 +34,4 @@ Guides on how to deploy your Buffalo application.
 
 The Buffalo community is a vibrant and growing community of developers and users. There is an ongoing conversation about tips and tricks, new features and ideas which takes place in the [Gophers Slack #buffalo channel](https://gophers.slack.com/messages/buffalo/).
 
-Besides the documentation itself, you can also get in touch with us on our [GitHub](https://github.com/gobuffalo/buffalo) or [Twitter](https://twitter.com/gobuffalo) accounts.
+Besides the documentation itself, you can also get in touch with us on our [GitHub](https://github.com/gobuffalo/buffalo) or [Twitter](https://twitter.com/gobuffalo_io) accounts.

--- a/content/documentation/_index.pt.md
+++ b/content/documentation/_index.pt.md
@@ -34,4 +34,4 @@ Guides on how to deploy your Buffalo application.
 
 The Buffalo community is a vibrant and growing community of developers and users. There is an ongoing conversation about tips and tricks, new features and ideas which takes place in the [Gophers Slack #buffalo channel](https://gophers.slack.com/messages/buffalo/).
 
-Besides the documentation itself, you can also get in touch with us on our [GitHub](https://github.com/gobuffalo/buffalo) or [Twitter](https://twitter.com/gobuffalo) accounts.
+Besides the documentation itself, you can also get in touch with us on our [GitHub](https://github.com/gobuffalo/buffalo) or [Twitter](https://twitter.com/gobuffalo_io) accounts.

--- a/content/documentation/support.es.md
+++ b/content/documentation/support.es.md
@@ -17,7 +17,7 @@ In order to access the Gophers Slack, and the `#buffalo` channel, you first need
 
 Once you're in Slack, please join the `#buffalo` channel and say "Hello"! We'd love to hear from you.
 
-Además de la documentación, también puedes ponerte en contacto con nosotros en nuestras cuentas de [GitHub](https://github.com/gobuffalo/buffalo) o [Twitter](https://twitter.com/gobuffalo).
+Además de la documentación, también puedes ponerte en contacto con nosotros en nuestras cuentas de [GitHub](https://github.com/gobuffalo/buffalo) o [Twitter](https://twitter.com/gobuffalo_io).
 
 ## Auditoria en proyectos de Buffalo
 

--- a/content/documentation/support.fr.md
+++ b/content/documentation/support.fr.md
@@ -17,7 +17,7 @@ Pour pouvoir accéder au Slack Gophers, ainsi qu'aux canaux `#buffalo_fr` et `#b
 
 Une fois sur Slack, rejoignez le canal `#buffalo_fr` et dîtes bonjour. Nous vous attendons !
 
-Outre la documentation elle-même, vous pouvez également nous contacter sur nos comptes [GitHub](https://github.com/gobuffalo/buffalo) ou [Twitter](https://twitter.com/gobuffalo).
+Outre la documentation elle-même, vous pouvez également nous contacter sur nos comptes [GitHub](https://github.com/gobuffalo/buffalo) ou [Twitter](https://twitter.com/gobuffalo_io).
 
 ## Audit du projet Buffalo
 

--- a/content/documentation/support.md
+++ b/content/documentation/support.md
@@ -17,7 +17,7 @@ In order to access the Gophers Slack, and the `#buffalo` channel, you first need
 
 Once you're in Slack, please join the `#buffalo` channel and say "Hello"! We'd love to hear from you.
 
-Besides the documentation itself, you can also get in touch with us on our [GitHub](https://github.com/gobuffalo/buffalo) or [Twitter](https://twitter.com/gobuffalo) accounts.
+Besides the documentation itself, you can also get in touch with us on our [GitHub](https://github.com/gobuffalo/buffalo) or [Twitter](https://twitter.com/gobuffalo_io) accounts.
 
 
 ## Buffalo Project Audit


### PR DESCRIPTION
Was going through buffalo for a side project, found the broken link to Twitter

### What is being done in this PR?
> Fix the Twitter link in the docs

### What are the main choices made to get to this solution?
> Found the correct link with a quick search and replaced it across the docs